### PR TITLE
Fix clang-specific issues

### DIFF
--- a/Plugins/GameItems/Source/GameItems/Private/Equipment/GameEquipmentComponent.cpp
+++ b/Plugins/GameItems/Source/GameItems/Private/Equipment/GameEquipmentComponent.cpp
@@ -166,7 +166,7 @@ TArray<UGameEquipment*> UGameEquipmentComponent::FindAllEquipment(TSubclassOf<UG
 TArray<UGameEquipment*> UGameEquipmentComponent::FindAllEquipmentByInstigator(UObject* Instigator) const
 {
 	TArray<UGameEquipment*> Result;
-	for (const auto Entry : EquipmentList.GetEntries())
+	for (const auto &Entry : EquipmentList.GetEntries())
 	{
 		UGameEquipment* Equipment = Entry.Equipment;
 		if (IsValid(Equipment) && Equipment->GetInstigator() == Instigator)
@@ -180,7 +180,7 @@ TArray<UGameEquipment*> UGameEquipmentComponent::FindAllEquipmentByInstigator(UO
 TArray<UGameEquipment*> UGameEquipmentComponent::GetAllEquipment() const
 {
 	TArray<UGameEquipment*> Result;
-	for (const auto Entry : EquipmentList.GetEntries())
+	for (const auto &Entry : EquipmentList.GetEntries())
 	{
 		UGameEquipment* Equipment = Entry.Equipment;
 		if (IsValid(Equipment))

--- a/Plugins/GameItemsUI/Source/GameItemsUI/Private/ViewModels/GameItemViewModelResolver.cpp
+++ b/Plugins/GameItemsUI/Source/GameItemsUI/Private/ViewModels/GameItemViewModelResolver.cpp
@@ -1,7 +1,7 @@
 ﻿// Copyright Bohdon Sayre, All Rights Reserved.
 
 
-#include "ViewModels\GameItemViewModelResolver.h"
+#include "ViewModels/GameItemViewModelResolver.h"
 
 #include "GameItemContainerProvider.h"
 #include "GameItemSettings.h"

--- a/Plugins/GameItemsUI/Source/GameItemsUI/Private/ViewModels/VM_GameItemContainerTransfer.cpp
+++ b/Plugins/GameItemsUI/Source/GameItemsUI/Private/ViewModels/VM_GameItemContainerTransfer.cpp
@@ -22,7 +22,7 @@ void UVM_GameItemContainerTransfer::SetContainerB(UGameItemContainer* NewContain
 void UVM_GameItemContainerTransfer::MoveItem(UVM_GameItemSlot* SlotViewModel, bool bAllowPartial)
 {
 	if (AreContainersValid() && SlotViewModel &&
-		SlotViewModel->GetContainer() == ContainerA || SlotViewModel->GetContainer() == ContainerB)
+		(SlotViewModel->GetContainer() == ContainerA || SlotViewModel->GetContainer() == ContainerB))
 	{
 		UGameItemContainer* OtherContainer = SlotViewModel->GetContainer() == ContainerA ? ContainerB : ContainerA;
 		SlotViewModel->MoveItem(OtherContainer, bAllowPartial);


### PR DESCRIPTION
Several fixes caught in clang:

* For loop copy variable
* Invalid include separator character
* Ambiguity in `&&` and `||` operator