### PR TITLE
Update UIComponentClass metadata to include script path

### DIFF
--- a/Source/GameItemsPlugin/Demo/Interaction/DemoInteractionComponent.h
+++ b/Source/GameItemsPlugin/Demo/Interaction/DemoInteractionComponent.h
@@ -28,7 +28,7 @@ public:
 	TArray<TObjectPtr<UDemoInteraction>> Interactions;
 
 	/** The UI component to use for displaying interactions. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Meta = (MustImplement = "DemoInteractionUIInterface"))
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Meta = (MustImplement = "/Script/GameItemsPlugin.DemoInteractionUIInterface"))
 	TSubclassOf<USceneComponent> UIComponentClass;
 
 	UFUNCTION(BlueprintNativeEvent, BlueprintCallable)


### PR DESCRIPTION
Running Unreal Engine 5.7, the compiler requires this small change to the `meta` property specifier.