### PR TITLE
Fix equipment find skeletal mesh component for non-character pawns

### DIFF
--- a/Plugins/GameItems/Source/GameItems/Private/Equipment/GameEquipment.cpp
+++ b/Plugins/GameItems/Source/GameItems/Private/Equipment/GameEquipment.cpp
@@ -256,5 +256,11 @@ USceneComponent* UGameEquipment::GetTargetAttachComponent() const
 	{
 		return Char->GetMesh();
 	}
+
+	if (USkeletalMeshComponent* FoundSkeletalMesh = OwningActor->FindComponentByClass<USkeletalMeshComponent>())
+	{
+		return FoundSkeletalMesh;
+	}
+
 	return OwningActor->GetRootComponent();
 }


### PR DESCRIPTION
In my game I'm making use of a Pawn with a custom movement component.

- So the base character does not inherit from `ACharacter`.
- The root component is not a `USkeletalMeshComponent`

So attaching equipment fails in my case.
This commit creates a fallback where it looks for a `USkeletalMeshComponent` on the owning actor.